### PR TITLE
Patch the bashrc in home dir instead of home/ray

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -49,8 +49,9 @@ COPY Pipfile.lock ${HOME}
 RUN echo \
  && pipenv install \
  && rm -rf /tmp/* /root/.cache /root/.local \
- && touch ${HOME}/.bashrc \
  && chmod a+rwX -R ${HOME} \
+ && touch /home/.bashrc \
+ && chmod a+rwX -R /home \
  && echo
 
 # in the above, ray has been installed as a pipenv environment - if you want to run


### PR DESCRIPTION
Patch the bashrc in home dir instead of home/ray
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes:
```
Unable to use a TTY - input is not a terminal or the right kind of file
bash: cannot set terminal process group (-1): Inappropriate ioctl for device
bash: no job control in this shell
bash: /home/.bashrc: No such file or director
```